### PR TITLE
setup categories with context, start questions with context

### DIFF
--- a/db.json
+++ b/db.json
@@ -8,8 +8,7 @@
         7,
         13,
         19,
-        25,
-        31
+        25
       ]
     },
     {
@@ -20,8 +19,7 @@
         8,
         14,
         20,
-        26,
-        32
+        26
       ]
     },
     {
@@ -32,8 +30,7 @@
         9,
         15,
         21,
-        27,
-        33
+        27
       ]
     },
     {
@@ -44,8 +41,7 @@
         10,
         16,
         22,
-        28,
-        34
+        28
       ]
     },
     {
@@ -56,8 +52,7 @@
         11,
         17,
         23,
-        29,
-        35
+        29
       ]
     },
     {
@@ -68,8 +63,7 @@
         12,
         18,
         24,
-        30,
-        36
+        30
       ]
     }
   ],
@@ -80,7 +74,8 @@
       "answerText":"Harold & the Purple Crayon",
       "showQuestion":false,
       "value":200,
-      "clicked":false
+      "clicked":false,
+      "category_id":1
     },
     {
       "id":2,
@@ -88,7 +83,8 @@
       "answerText":"Cloth Diaper",
       "showQuestion":false,
       "value":200,
-      "clicked":false
+      "clicked":false,
+      "category_id":2
     },
     {
       "id":3,
@@ -97,7 +93,8 @@
       "showQuestion":false,
       "value":200,
       "clicked":false,
-      "src":"./images/200.jpeg"
+      "src":"./images/200.jpeg",
+      "category_id":3
     },
     {
       "id":4,
@@ -105,7 +102,8 @@
       "answerText":"Pick him/her up",
       "showQuestion":false,
       "value":200,
-      "clicked":false
+      "clicked":false,
+      "category_id":4
     },
     {
       "id":5,
@@ -113,7 +111,8 @@
       "answerText":"left",
       "showQuestion":false,
       "value":200,
-      "clicked":false
+      "clicked":false,
+      "category_id":5
     },
     {
       "id":6,
@@ -121,7 +120,8 @@
       "answerText":"Kathy Vogel",
       "showQuestion":false,
       "value":200,
-      "clicked":false
+      "clicked":false,
+      "category_id":6
     },
     {
       "id":7,
@@ -129,7 +129,8 @@
       "answerText":"Eric Carle",
       "showQuestion":false,
       "value":400,
-      "clicked":false
+      "clicked":false,
+      "category_id":1
     },
     {
       "id":8,
@@ -137,7 +138,8 @@
       "answerText":"Swaddlers",
       "showQuestion":false,
       "value":400,
-      "clicked":false
+      "clicked":false,
+      "category_id":2
     },
     {
       "id":9,
@@ -146,7 +148,8 @@
       "showQuestion":false,
       "value":400,
       "clicked":false,
-      "src":"./images/400.jpeg"
+      "src":"./images/400.jpeg",
+      "category_id":3
     },
     {
       "id":10,
@@ -154,7 +157,8 @@
       "answerText":"August 10th, 2021",
       "showQuestion":false,
       "value":400,
-      "clicked":false
+      "clicked":false,
+      "category_id":4
     },
     {
       "id":11,
@@ -162,7 +166,8 @@
       "answerText":"Scorpio",
       "showQuestion":false,
       "value":400,
-      "clicked":false
+      "clicked":false,
+      "category_id":5
     },
     {
       "id":12,
@@ -170,7 +175,8 @@
       "answerText":"Marti Estey (usually at least 50% of the check!)",
       "showQuestion":false,
       "value":400,
-      "clicked":false
+      "clicked":false,
+      "category_id":6
     },
     {
       "id":13,
@@ -178,7 +184,8 @@
       "answerText":"Charlotte’s Web",
       "showQuestion":false,
       "value":600,
-      "clicked":false
+      "clicked":false,
+      "category_id":1
     },
     {
       "id":14,
@@ -186,7 +193,8 @@
       "answerText":"Rash Cream",
       "showQuestion":false,
       "value":600,
-      "clicked":false
+      "clicked":false,
+      "category_id":2
     },
     {
       "id":15,
@@ -195,7 +203,8 @@
       "showQuestion":false,
       "value":600,
       "clicked":false,
-      "src":"./images/600.jpeg"
+      "src":"./images/600.jpeg",
+      "category_id":3
     },
     {
       "id":16,
@@ -203,7 +212,8 @@
       "answerText":"Animals",
       "showQuestion":false,
       "value":600,
-      "clicked":false
+      "clicked":false,
+      "category_id":4
     },
     {
       "id":17,
@@ -211,7 +221,8 @@
       "answerText":"Philadelphia",
       "showQuestion":false,
       "value":600,
-      "clicked":false
+      "clicked":false,
+      "category_id":5
     },
     {
       "id":18,
@@ -219,7 +230,8 @@
       "answerText":"Peg Unger",
       "showQuestion":false,
       "value":600,
-      "clicked":false
+      "clicked":false,
+      "category_id":6
     },
     {
       "id":19,
@@ -227,7 +239,8 @@
       "answerText":"Winnie the Pooh",
       "showQuestion":false,
       "value":800,
-      "clicked":false
+      "clicked":false,
+      "category_id":1
     },
     {
       "id":20,
@@ -235,7 +248,8 @@
       "answerText":"Huggies",
       "showQuestion":false,
       "value":800,
-      "clicked":false
+      "clicked":false,
+      "category_id":2
     },
     {
       "id":21,
@@ -244,7 +258,8 @@
       "showQuestion":false,
       "value":800,
       "clicked":false,
-      "src":"./images/800.jpeg"
+      "src":"./images/800.jpeg",
+      "category_id":3
     },
     {
       "id":22,
@@ -252,7 +267,8 @@
       "answerText":"Jumped up & down; screamed",
       "showQuestion":false,
       "value":800,
-      "clicked":false
+      "clicked":false,
+      "category_id":4
     },
     {
       "id":23,
@@ -260,7 +276,8 @@
       "answerText":"Nick",
       "showQuestion":false,
       "value":800,
-      "clicked":false
+      "clicked":false,
+      "category_id":5
     },
     {
       "id":24,
@@ -268,7 +285,8 @@
       "answerText":"Molly Hemes",
       "showQuestion":false,
       "value":800,
-      "clicked":false
+      "clicked":false,
+      "category_id":6
     },
     {
       "id":25,
@@ -276,7 +294,8 @@
       "answerText":"Elephants",
       "showQuestion":false,
       "value":1000,
-      "clicked":false
+      "clicked":false,
+      "category_id":1
     },
     {
       "id":26,
@@ -284,7 +303,8 @@
       "answerText":"Nappy",
       "showQuestion":false,
       "value":1000,
-      "clicked":false
+      "clicked":false,
+      "category_id":2
     },
     {
       "id":27,
@@ -293,7 +313,8 @@
       "showQuestion":false,
       "value":1000,
       "clicked":false,
-      "src":"./images/1000.jpeg"
+      "src":"./images/1000.jpeg",
+      "category_id":3
     },
     {
       "id":28,
@@ -301,7 +322,8 @@
       "answerText":"Cheetah & Lion",
       "showQuestion":false,
       "value":1000,
-      "clicked":false
+      "clicked":false,
+      "category_id":4
     },
     {
       "id":29,
@@ -309,7 +331,8 @@
       "answerText":"North High School",
       "showQuestion":false,
       "value":1000,
-      "clicked":false
+      "clicked":false,
+      "category_id":4
     },
     {
       "id":30,
@@ -317,7 +340,8 @@
       "answerText":"Kris Paul",
       "showQuestion":false,
       "value":1000,
-      "clicked":false
+      "clicked":false,
+      "category_id":6
     }
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 
+import { LoadingContextProvider } from 'contexts';
 import Header from 'components/Header';
 import Board from 'components/Board';
 
@@ -14,7 +15,9 @@ const App = () => {
       className="app"
     >
       <Header />
-      <Board />
+      <LoadingContextProvider>
+        <Board />
+      </LoadingContextProvider>
     </Box>
   );
 };

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
-import { QuestionsContext } from 'contexts';
-import { questionOne, questionTwo, questions } from 'mocks/question';
+import { MainContext } from 'contexts';
+import { questions } from 'mocks/question';
+import { categories } from 'mocks/category';
 import { server } from 'mocks/server';
 
 import Board from './Board';
@@ -9,9 +10,9 @@ describe('board', () => {
 	beforeAll(() => server.listen())
 	test('renders loader ', async () => {
 	  const wrapper = render(
-	  	<QuestionsContext.Provider value={questions}>
+	  	<MainContext.Provider value={{questions, categories}}>
 	  		<Board />
-	  	</QuestionsContext.Provider>
+	  	</MainContext.Provider>
 	  );
 
 	  const loadingText = wrapper.getByText('Loading ...');
@@ -20,9 +21,9 @@ describe('board', () => {
 
 	test('renders categories ', async () => {
 	  const wrapper = render(
-	  	<QuestionsContext.Provider value={questions}>
+	  	<MainContext.Provider value={{questions, categories}}>
 	  		<Board />
-	  	</QuestionsContext.Provider>
+	  	</MainContext.Provider>
 	  );
 
 	  await waitFor(() => expect(wrapper.getByText('Authors')).toBeVisible());

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,50 +1,25 @@
-import { useEffect, useState } from 'react';
 import { Box } from '@mui/material';
 
-import { Category as CategoryType, Categories, Questions } from 'models/types';
-import Category from './Category';
+import Categories from './Categories';
 
-import { getCategories, getQuestions } from 'models/api';
-import { QuestionsContext } from 'contexts';
-
-import Loader from 'components/Loader';
+import {
+	MainContextProvider,
+} from 'contexts';
 
 const Board = () => {
-	const [categories, setCategories] = useState<Categories>([]);
-  const [questions, setQuestions] = useState<Questions>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-	useEffect(() => {
-    (async () => {
-      const categories = await getCategories();
-      const questions = await getQuestions();
-
-      setCategories(categories);
-      setQuestions(questions);
-      setIsLoading(false);
-    })();
-  }, []);
-
 	return (
-		<Box
-			width="98%"
-			marginLeft="auto"
-			marginRight="auto"
-			display="flex"
-			alignItems="center"
-			justifyContent="center"
-		>
-			{ isLoading ?
-				<Loader /> : 
-	      <QuestionsContext.Provider value={questions}>
-		      { 
-		        categories.map((c: CategoryType) => {
-		          return(<Category key={c.id} category={c} />)
-		        })
-		      }
-			  </QuestionsContext.Provider>
-			}
-		</Box>
+		<MainContextProvider>
+			<Box
+				width="98%"
+				marginLeft="auto"
+				marginRight="auto"
+				display="flex"
+				alignItems="center"
+				justifyContent="center"
+			>
+				<Categories />
+			</Box>
+		</MainContextProvider>
 	)
 };
 

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -1,0 +1,25 @@
+import { useContext } from 'react';
+import { Category as CategoryType, Categories as CategoriesType } from 'models/types';
+import Category from './Category';
+import Loader from 'components/Loader';
+import { MainContext, useLoading } from 'contexts';
+
+const Categories = () => {
+	const { loading } = useLoading();
+
+	const data = useContext(MainContext);
+	const categories: CategoriesType = data.categories;
+
+	return (
+		<>
+		  { loading && <Loader /> }
+      { 
+        !loading && categories.map((c: CategoryType) => {
+          return(<Category key={c.id} category={c} />)
+        })
+      }
+	  </>
+	);
+};
+
+export default Categories;

--- a/src/components/Category.test.tsx
+++ b/src/components/Category.test.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
-import { CategoryOne } from 'mocks/category';
+import { categoryOne } from 'mocks/category';
 import Category, { CategoryProps } from './Category';
 
 test('renders Category', () => {
-  const props: CategoryProps = { category: CategoryOne };
+  const props: CategoryProps = { category: categoryOne };
 
   const wrapper = render(<Category {...props} />);
   const headerText = wrapper.getByText('State Facts');

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,12 +1,15 @@
 import { Box } from '@mui/material';
 import { Category as CategoryType } from 'models/types';
 import CategoryHeader from './CategoryHeader';
+// import useCategoryQuestions from './useCategoryQuestions';
 
 export interface CategoryProps {
 	category: CategoryType;
 };
 
 const Category = ({ category }: CategoryProps) => {
+	// const categoryQuestions = useCategoryQuestions(category.id)
+
 	return (
 		<Box
 			width="100%"

--- a/src/components/useCategoryQuestions.tsx
+++ b/src/components/useCategoryQuestions.tsx
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { Question, Questions } from 'models/types';
+import { MainContext } from 'contexts';
+
+const useCategoryQuestions = (categoryId: number) => {
+	const data = useContext(MainContext);
+
+	const allQuestions: Questions = data.questions;
+
+	const categoryQuestions = allQuestions
+		.filter((question: Question) => question.categoryId === categoryId)
+		.sort((a: Question, b: Question) => {
+			return a.value - b.value;
+		});
+
+	return categoryQuestions;
+};
+
+export default useCategoryQuestions;

--- a/src/contexts/LoadingContextProvider.tsx
+++ b/src/contexts/LoadingContextProvider.tsx
@@ -1,0 +1,27 @@
+import { createContext, useState, useContext, ReactNode } from 'react';
+
+type LoadingContextType = {
+  loading: boolean;
+  setLoading: (loading: boolean) => void;
+}
+
+export const LoadingContext = createContext<LoadingContextType>({
+  loading: false,
+  setLoading: () => {}
+});
+
+export const LoadingContextProvider = ({ children }: { children: ReactNode }) => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const value = { loading, setLoading };
+  return (
+    <LoadingContext.Provider value={value}>{children}</LoadingContext.Provider>
+  );
+};
+
+export const useLoading = () => {
+  const context = useContext(LoadingContext);
+  if (!context) {
+    throw new Error("useLoading must be used within LoadingProvider");
+  }
+  return context;
+}

--- a/src/contexts/MainContextProvider.tsx
+++ b/src/contexts/MainContextProvider.tsx
@@ -1,0 +1,35 @@
+import { createContext, useState, useEffect, ReactNode } from 'react';
+import { Categories, Questions } from 'models/types';
+import { useLoading } from './LoadingContextProvider';
+
+import { getCategories, getQuestions } from 'models/api'
+
+export const MainContext = 
+    createContext<{ questions: Questions, categories: Categories}>({ questions: [], categories: [] });
+
+const MainContextProvider = ({ children }: { children: ReactNode }) => {
+  const { setLoading } = useLoading();
+  const [questions, setQuestions] = useState<Questions>([]);
+  const [categories, setCategories] = useState<Categories>([]);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true)
+      const categoriesResponse = await getCategories();
+      setCategories(categoriesResponse);
+
+      const questionsResponse = await getQuestions();
+      setQuestions(questionsResponse);
+
+      setLoading(false)
+    })();
+  },[setLoading]);
+
+  return (
+    <MainContext.Provider value={{questions, categories}}>
+      {children}
+    </MainContext.Provider>
+  );
+}
+
+export default MainContextProvider;

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,5 +1,2 @@
-import { createContext } from 'react';
-import { Questions } from 'models/types';
-
-export const QuestionsContext = 
-    createContext<Questions>([]);
+export { default as MainContextProvider, MainContext } from './MainContextProvider';
+export { LoadingContextProvider, useLoading } from './LoadingContextProvider';

--- a/src/mocks/category.ts
+++ b/src/mocks/category.ts
@@ -1,7 +1,15 @@
 import { Category } from 'models/types';
 
-export const CategoryOne: Category = {
+export const categoryOne: Category = {
 	id: 1,
 	name: 'State Facts',
 	questionIds: [1, 2]
 };
+
+export const categoryTwo: Category = {
+	id: 2,
+	name: 'Nature',
+	questionIds: [2, 3]
+};
+
+export const categories = [categoryOne, categoryTwo]

--- a/src/mocks/question.ts
+++ b/src/mocks/question.ts
@@ -6,7 +6,8 @@ export const questionOne: Question = {
   answerText: "Harold & the Purple Crayon",
   showQuestion: false,
   value: 200,
-  clicked: false
+  clicked: false,
+  categoryId: 1
 };
 
 export const questionTwo: Question = {
@@ -15,7 +16,8 @@ export const questionTwo: Question = {
   answerText: "Cloth Diaper",
   showQuestion: false,
   value: 200,
-  clicked: false
+  clicked: false,
+  categoryId: 2
 };
 
 export const questions = [questionOne, questionTwo];

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -39,7 +39,8 @@ export const getQuestions = async (): Promise<Questions> => {
 					answerText: parseString(question.answerText),
 					showQuestion: question.showQuestion,
 					value: parseNumber(question.value),
-					clicked: question.clicked
+					clicked: question.clicked,
+					categoryId: parseNumber(question.category_id),
 				})
 			}
 		};
@@ -61,11 +62,11 @@ export const getCategories = async (): Promise<Categories> => {
 			for (const category of categoriesResponse) {
 				const questionIds: number[] = [];
 
-				for (const questionId of questionIds) {
+				for (const questionId of category.question_ids) {
 					questionIds.push(parseNumber(questionId));
 				}
 
-				category.push({
+				categories.push({
 					id: parseNumber(category.id),
 					name: parseString(category.name),
 					questionIds

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -5,6 +5,7 @@ export interface Question {
 	showQuestion: boolean;
 	value: number;
 	clicked: boolean;
+	categoryId: number;
 };
 
 export type Questions = Question[];


### PR DESCRIPTION
## What Changes
- add question ids to category
- make sure questions know their category id
- setup main context to get and store data
- setup question context to be used when rendering category questions in the next PR
- separate app component beef into a smaller components for clarity