### PR TITLE
rebuild questions so they're by category

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "msw": "^0.49.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.6.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,11 @@
 import { Box } from '@mui/material';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { LoadingContextProvider, MainContextProvider } from 'contexts';
 
-import { LoadingContextProvider } from 'contexts';
-import Header from 'components/Header';
 import Board from 'components/Board';
+import Header from 'components/Header';
+import Question from 'components/Question';
+import NotFoundPage from 'components/NotFoundPage';
 
 import 'styles/app.css';
 
@@ -14,10 +17,23 @@ const App = () => {
       flexDirection="column"
       className="app"
     >
-      <Header />
-      <LoadingContextProvider>
-        <Board />
-      </LoadingContextProvider>
+      <Router>
+        <LoadingContextProvider>
+          <MainContextProvider>
+
+            <Header />
+
+            <Routes>
+              <Route path="/" element={<Board />} />
+
+              <Route path="category/:categoryId/question/:questionValue" element={<Question />} />
+
+              <Route path="*" element={<NotFoundPage />} /> 
+            </Routes>
+          
+          </MainContextProvider>
+        </LoadingContextProvider>
+      </Router>
     </Box>
   );
 };

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -7,10 +7,12 @@ import { server } from 'mocks/server';
 import Board from './Board';
 
 describe('board', () => {
+	const setQuestions = jest.fn();
+
 	beforeAll(() => server.listen())
 	test('renders loader ', async () => {
 	  const wrapper = render(
-	  	<MainContext.Provider value={{questions, categories}}>
+	  	<MainContext.Provider value={{questions, setQuestions, categories}}>
 	  		<Board />
 	  	</MainContext.Provider>
 	  );
@@ -21,7 +23,7 @@ describe('board', () => {
 
 	test('renders categories ', async () => {
 	  const wrapper = render(
-	  	<MainContext.Provider value={{questions, categories}}>
+	  	<MainContext.Provider value={{questions, setQuestions, categories}}>
 	  		<Board />
 	  	</MainContext.Provider>
 	  );

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,25 +1,18 @@
 import { Box } from '@mui/material';
-
 import Categories from './Categories';
-
-import {
-	MainContextProvider,
-} from 'contexts';
 
 const Board = () => {
 	return (
-		<MainContextProvider>
-			<Box
-				width="98%"
-				marginLeft="auto"
-				marginRight="auto"
-				display="flex"
-				alignItems="center"
-				justifyContent="center"
-			>
-				<Categories />
-			</Box>
-		</MainContextProvider>
+		<Box
+			width="98%"
+			marginLeft="auto"
+			marginRight="auto"
+			display="flex"
+			alignItems="center"
+			justifyContent="center"
+		>
+			<Categories />
+		</Box>
 	)
 };
 

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -3,11 +3,12 @@ import { Category as CategoryType, Categories as CategoriesType } from 'models/t
 import Category from './Category';
 import Loader from 'components/Loader';
 import { MainContext, useLoading } from 'contexts';
+import { MainContextType } from 'models/types';
 
 const Categories = () => {
 	const { loading } = useLoading();
 
-	const data = useContext(MainContext);
+	const data: MainContextType = useContext(MainContext);
 	const categories: CategoriesType = data.categories;
 
 	return (

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,14 +1,15 @@
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { Category as CategoryType } from 'models/types';
 import CategoryHeader from './CategoryHeader';
-// import useCategoryQuestions from './useCategoryQuestions';
+import QuestionValue from './QuestionValue';
+import { QUESTION_VALUES } from 'config/constants';
 
 export interface CategoryProps {
 	category: CategoryType;
 };
 
 const Category = ({ category }: CategoryProps) => {
-	// const categoryQuestions = useCategoryQuestions(category.id)
+	const theme = useTheme();
 
 	return (
 		<Box
@@ -17,9 +18,18 @@ const Category = ({ category }: CategoryProps) => {
 			flexDirection="column"
 			justifyContent="center"
 			alignItems="center"
-			margin={0.5}
+			margin={theme.spacing(0.5)}
 		>
 			<CategoryHeader name={category.name} />
+
+			{QUESTION_VALUES.map((qValue) => (
+        <QuestionValue
+        	key={qValue}
+        	categoryId={category.id}
+        	questionValue={qValue}
+        />
+      ))}
+
 		</Box>
 	);
 };

--- a/src/components/CategoryHeader.tsx
+++ b/src/components/CategoryHeader.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, useMediaQuery, useTheme } from '@mui/material';
 import 'styles/board.css';
 
 export interface CategoryHeaderProps {
@@ -6,11 +6,25 @@ export interface CategoryHeaderProps {
 };
 
 const CategoryHeader = ({ name }: CategoryHeaderProps) => {
+	const theme = useTheme();
+	const isMobile: boolean = !useMediaQuery(theme.breakpoints.up('md'));
+
+	const styles = {
+		minHeight: isMobile ? "80px" : "60px",
+		padding: isMobile ? "0 10 0 10" : "",
+	}
+
 	return (
 		<Box
 			width="100%"
 			className="category-header"
+			display="flex"
+			flexDirection="column"
+			justifyContent="center"
+			alignItems="center"
 			textAlign="center"
+			marginBottom={theme.spacing(2)}
+			sx={styles}
 		>
 			<h4>{name}</h4>
 		</Box>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import { Box } from '@mui/material';
+import { Link } from 'react-router-dom';
+import 'styles/app.css';
 import 'styles/header.css';
 
 const Header = () => {
@@ -10,7 +12,9 @@ const Header = () => {
 			justifyContent="center"
 			alignItems="center"
 		>
-			<h1 className="header">Quiz Game!</h1>
+			<Link to="/" className="link">
+				<h1 className="header">Quiz Game!</h1>
+			</Link>
 		</Box>
 	)
 };

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+import { Box } from '@mui/material';
+
+const NotFoundPage = () => {
+  return (
+    <Box width="100%">
+      <h1>Ops! This page doesn't exist</h1>
+      <Link to="/">
+        <h4>Go to Home</h4>
+        </Link>
+    </Box>
+  )
+};
+
+export default NotFoundPage;

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Box, Button, Paper } from '@mui/material';
+import useQuestion from './useQuestion';
+import useCategory from './useCategory';
+import CategoryHeader from './CategoryHeader';
+import 'styles/question.css';
+
+const Question = () => {
+	let navigate = useNavigate();
+	const { categoryId, questionValue } = useParams();
+	const question = useQuestion(Number(categoryId), Number(questionValue));
+	const category = useCategory(Number(categoryId));
+
+	const [showAnswer, setShowAnswer] = useState<boolean>(false);
+
+	const handleButtonClick = () => {
+		if (showAnswer) {
+			// fix me
+			navigate('/')
+		} else {
+			setShowAnswer(true)
+			question.clicked = true;
+		}
+	}
+
+	return (
+		<Box
+			className="quesiton-view"
+			minWidth="70%"
+			marginLeft="auto"
+			marginRight="auto"
+		>
+			<Paper variant="outlined" square>
+				<Box
+					display='flex'
+					flexDirection='column'
+					justifyContent='center'
+					alignItems='center'
+					paddingBottom={2}
+					className="question-view"
+				>
+					<CategoryHeader name={category.name} />
+
+					<Box height="60px" margin={2}>
+						<h2>{ showAnswer ? question.answerText : question.questionText}</h2>
+					</Box>
+
+					<Button variant="contained" color="warning" onClick={() => handleButtonClick()}>{ showAnswer ? 'Back to Board' : 'Reveal' }</Button>
+					
+				</Box>
+			</Paper>
+		</Box>
+		
+	)
+};
+export default Question;

--- a/src/components/QuestionValue.tsx
+++ b/src/components/QuestionValue.tsx
@@ -1,0 +1,53 @@
+import { Box, useTheme } from '@mui/material';
+import { Link } from 'react-router-dom';
+import useQuestion from './useQuestion';
+import "styles/app.css";
+import "styles/question.css";
+
+export interface QuestionValueProps {
+	categoryId: number;
+	questionValue: number;
+};
+
+const QuestionValue = ({ categoryId, questionValue }: QuestionValueProps) => {
+	const { spacing } = useTheme();
+	const question = useQuestion(Number(categoryId), Number(questionValue));
+	const questionLink = `category/${categoryId}/question/${question.value}`;
+
+	const hasBeenAnswered = question.clicked;
+
+	if (hasBeenAnswered) {
+		return (
+			<Box width="100%">
+					<Box
+						width="100%"
+						height="150px"
+						display="flex"
+						justifyContent="center"
+						alignItems="center"
+						marginTop={spacing(0.5)}
+						className="question-box"
+					/>
+			</Box>
+		)
+	} else {
+		return (
+			<Box width="100%">
+				<Link to={questionLink} className="link">
+					<Box
+						width="100%"
+						height="150px"
+						display="flex"
+						justifyContent="center"
+						alignItems="center"
+						marginTop={spacing(0.5)}
+						className="question-box"
+					>
+						<h1 className="question-value">${questionValue}</h1>
+					</Box>
+				</Link>
+			</Box>
+		)
+	};
+};
+export default QuestionValue;

--- a/src/components/useCategory.ts
+++ b/src/components/useCategory.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { Categories, MainContextType } from 'models/types';
+import { newEmptyCategory } from 'models/api';
+import { MainContext } from 'contexts';
+
+const useCategory = (categoryId: number) => {
+	const data: MainContextType = useContext(MainContext);
+	const allCategories: Categories = data.categories;
+	const category = allCategories.find((c) => c.id === categoryId) ?? newEmptyCategory();
+
+	return category;
+};
+
+export default useCategory;

--- a/src/components/useCategoryQuestions.tsx
+++ b/src/components/useCategoryQuestions.tsx
@@ -1,9 +1,9 @@
 import { useContext } from 'react';
-import { Question, Questions } from 'models/types';
+import { Question, Questions, MainContextType } from 'models/types';
 import { MainContext } from 'contexts';
 
 const useCategoryQuestions = (categoryId: number) => {
-	const data = useContext(MainContext);
+	const data: MainContextType = useContext(MainContext);
 
 	const allQuestions: Questions = data.questions;
 

--- a/src/components/useQuestion.ts
+++ b/src/components/useQuestion.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { Questions, MainContextType } from 'models/types';
+import { newEmptyQuestion } from 'models/api';
+import { MainContext } from 'contexts';
+
+const useQuestion = (categoryId: number, questionValue: number) => {
+	const data: MainContextType = useContext(MainContext);
+	const allQuestions: Questions = data.questions;
+	const question = allQuestions.find((q) => q.categoryId === categoryId && q.value === questionValue) ?? newEmptyQuestion();
+
+	return question;
+};
+
+export default useQuestion;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,1 @@
+export const QUESTION_VALUES = [200, 400, 600, 800, 1000];

--- a/src/contexts/MainContextProvider.tsx
+++ b/src/contexts/MainContextProvider.tsx
@@ -1,11 +1,16 @@
-import { createContext, useState, useEffect, ReactNode } from 'react';
-import { Categories, Questions } from 'models/types';
+import { createContext, useState, useEffect, Dispatch, ReactNode } from 'react';
+import { Categories, Questions, MainContextType } from 'models/types';
 import { useLoading } from './LoadingContextProvider';
 
 import { getCategories, getQuestions } from 'models/api'
 
+/**
+ * Context here is going to include both categories and questions. Since
+ * this app is small and questions/categories depend on one another, the
+ * extra rerenders won't degrade performance much.
+ * */
 export const MainContext = 
-    createContext<{ questions: Questions, categories: Categories}>({ questions: [], categories: [] });
+    createContext<{ questions: Questions, setQuestions: Dispatch<React.SetStateAction<Questions>>, categories: Categories}>({ questions: [], setQuestions: () => {}, categories: [] });
 
 const MainContextProvider = ({ children }: { children: ReactNode }) => {
   const { setLoading } = useLoading();
@@ -25,8 +30,10 @@ const MainContextProvider = ({ children }: { children: ReactNode }) => {
     })();
   },[setLoading]);
 
+  const data: MainContextType = { questions, setQuestions, categories };
+
   return (
-    <MainContext.Provider value={{questions, categories}}>
+    <MainContext.Provider value={data}>
       {children}
     </MainContext.Provider>
   );

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -80,3 +80,27 @@ export const getCategories = async (): Promise<Categories> => {
 		return e.message;
 	}
 };
+
+export const newEmptyQuestion = () => {
+	return (
+		{
+			id: Math.random(),
+			questionText: '',
+			answerText: '',
+			showQuestion: false,
+			value: Math.random(),
+			clicked: false,
+			categoryId: Math.random()
+		}
+	)
+};
+
+export const newEmptyCategory = () => {
+	return (
+	{
+		id: Math.random(),
+		name: '',
+		questionIds: []
+	}
+	)
+}

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,3 +1,5 @@
+import { Dispatch } from 'react';
+
 export interface Question {
 	id: number;
 	questionText: string;
@@ -21,4 +23,10 @@ export type Categories = Category[];
 export interface ApiDataResponse {
 	questions: Questions;
 	categories: Categories;
-}
+};
+
+export interface MainContextType {
+	questions: Questions;
+	setQuestions: Dispatch<React.SetStateAction<Questions>>
+	categories: Categories;
+};

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,3 +1,8 @@
 .app {
   background: #00003a;
+  height: 1000px;
+}
+
+.link {
+  text-decoration: none;
 }

--- a/src/styles/question.css
+++ b/src/styles/question.css
@@ -1,0 +1,31 @@
+.question-box {
+  box-shadow: inset 1px 1px 1px 1px #0600ed;
+  background-color: #0300af;
+  border-top: 5px solid #00003a;
+  border-left: 5px solid #00003a;
+  border-right: 5px solid #00003a;
+  border-bottom: 5px solid #00003a;
+  vertical-align: none;
+  padding: none;
+}
+
+.question-value {
+  color: #f29649;
+  text-shadow: 2px 2px 2px #000;
+  font-weight: bold;
+  font-size: 50px;
+  cursor: pointer;
+
+  text-transform: uppercase;
+  text-decoration: none;
+  transform: scale(1, 2.5);
+  -webkit-transform: scale(1, 2.5); /* Safari and Chrome */
+  -moz-transform: scale(1, 2.5); /* Firefox */
+  -ms-transform: scale(1, 2.5); /* IE 9+ */
+  -o-transform: scale(1, 2.5); /* Opera */
+}
+
+.quesiton-view {
+  background-color: #00003a;
+  color: white;
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,4 @@
+import { createTheme } from "@mui/material/styles";
+
+export const appTheme = createTheme();
+export default appTheme;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,6 +1798,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
+"@remix-run/router@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.2.1.tgz#812edd4104a15a493dda1ccac0b352270d7a188c"
+  integrity sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -7982,6 +7987,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.6.1.tgz#1b96ec0b2cefa7319f1251383ea5b41295ee260d"
+  integrity sha512-u+8BKUtelStKbZD5UcY0NY90WOzktrkJJhyhNg7L0APn9t1qJNLowzrM9CHdpB6+rcPt6qQrlkIXsTvhuXP68g==
+  dependencies:
+    "@remix-run/router" "1.2.1"
+    react-router "6.6.1"
+
+react-router@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.6.1.tgz#17de6cf285f2d1c9721a3afca999c984e5558854"
+  integrity sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==
+  dependencies:
+    "@remix-run/router" "1.2.1"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## What Changes
- render questions using context in conjunction with it's category
- use react-router to have defined question links for easier api implementation down the road
- re-ogranize question related components to prevent extra renders and make code more readable

## Why
Previously, questions and category were not using one another (we're hard coded) and that it just bad. Now questions will be attached to the category they're in. It also allows categories to be swapped out so as more categories (and questions) are added, the game board doesn't have to be fixed to a particular set of categories.

Adding react-router allows for future support of an api and having named category/question urls